### PR TITLE
Skip padding results

### DIFF
--- a/password.go
+++ b/password.go
@@ -118,6 +118,9 @@ func (p *PwnedPassApi) ListHashesPrefix(pf string) ([]Match, *http.Response, err
 		if err != nil {
 			continue
 		}
+		if hc == 0 {
+			continue
+		}
 		pwMatches = append(pwMatches, Match{
 			Hash:  fh,
 			Count: hc,


### PR DESCRIPTION
Patch for #14

Skip `padding` results in the API response, which can be identified by having a zero count.
