### PR TITLE
Add latestbreach api

### DIFF
--- a/breach.go
+++ b/breach.go
@@ -161,6 +161,22 @@ func (b *BreachAPI) BreachByName(n string, options ...BreachOption) (*Breach, *h
 	return bd, hr, nil
 }
 
+// LatestBreach returns the single most recent breach
+func (b *BreachAPI) LatestBreach() (*Breach, *http.Response, error) {
+	au := fmt.Sprintf("%s/latestbreach", BaseURL)
+	hb, hr, err := b.hibp.HTTPResBody(http.MethodGet, au, nil)
+	if err != nil {
+		return nil, hr, err
+	}
+
+	var bd *Breach
+	if err := json.Unmarshal(hb, &bd); err != nil {
+		return nil, hr, err
+	}
+
+	return bd, hr, nil
+}
+
 // DataClasses are attribute of a record compromised in a breach. This method returns a list of strings
 // with all registered data classes known to HIBP
 func (b *BreachAPI) DataClasses() ([]string, *http.Response, error) {

--- a/breach_test.go
+++ b/breach_test.go
@@ -162,6 +162,20 @@ func TestBreachAPI_BreachByName_Errors(t *testing.T) {
 	}
 }
 
+// TestBreachAPI_LatestBreach tests the LatestBreach method of the breaches API
+func TestBreachAPI_LatestBreach(t *testing.T) {
+	hc := New()
+	breach, _, err := hc.BreachAPI.LatestBreach()
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	if breach == nil {
+		t.Error("No breach returned")
+	}
+}
+
 // TestBreachAPI_DataClasses tests the DataClasses() method of the breaches API
 func TestBreachAPI_DataClasses(t *testing.T) {
 	hc := New()


### PR DESCRIPTION
Apparently the preferred way to see if there's any point in querying the rest of the domain APIs is to call the [latestbreach api](https://haveibeenpwned.com/API/v3#MostRecentBreach) first so... I've added support for [latestbreach](https://haveibeenpwned.com/API/v3#MostRecentBreach)