### PR TITLE
feat: Add support for user provided http client

### DIFF
--- a/hibp.go
+++ b/hibp.go
@@ -104,8 +104,10 @@ func New(options ...Option) Client {
 		opt(&c)
 	}
 
-	// Add a http client to the Client object
-	c.hc = httpClient(c.to)
+	if c.hc == nil {
+		// Add a http client to the Client object
+		c.hc = httpClient(c.to)
+	}
 
 	// Associate the different HIBP service APIs with the Client
 	c.PwnedPassAPI = &PwnedPassAPI{
@@ -165,6 +167,13 @@ func WithRateLimitSleep() Option {
 func WithPwnedNTLMHash() Option {
 	return func(c *Client) {
 		c.PwnedPassAPIOpts.HashMode = HashModeNTLM
+	}
+}
+
+// WithHTTPClient sets a custom http client to the HIBP client object
+func WithHTTPClient(hc *http.Client) Option {
+	return func(c *Client) {
+		c.hc = hc
 	}
 }
 

--- a/hibp_test.go
+++ b/hibp_test.go
@@ -88,6 +88,17 @@ func TestNewWithUserAgent(t *testing.T) {
 	}
 }
 
+// TestNewWithHTTPClient tests the New() function with a custom HTTP client
+func TestNewWithHTTPClient(t *testing.T) {
+	customClient := &http.Client{}
+
+	hc := New(WithHTTPClient(customClient))
+	if hc.hc != customClient {
+		t.Errorf("hibp client custom http client option was not set properly. Expected %v, got: %v",
+			customClient, hc.hc)
+	}
+}
+
 func TestClient_HTTPReq(t *testing.T) {
 	u1 := "this://is.invalid.tld/with/invalid/chars/" + string([]byte{0x7f})
 	u2 := "this://is.invalid.tld/"


### PR DESCRIPTION
Add option to provide a `net/http` client, useful when you want to customize the client options (e.g. instrumenting with OTel)