### PR TITLE
Use a custom logger

### DIFF
--- a/hibp_test.go
+++ b/hibp_test.go
@@ -1,6 +1,7 @@
 package hibp
 
 import (
+	"bufio"
 	"fmt"
 	"net/http"
 	"os"
@@ -85,6 +86,26 @@ func TestNewWithUserAgent(t *testing.T) {
 	if hc.ua != DefaultUserAgent {
 		t.Errorf("hibp client custom user agent was not set properly. Expected %s, got: %s",
 			DefaultUserAgent, hc.ua)
+	}
+}
+
+// TestNewWithLogger tests the New() function with a custom logger
+func TestNewWithLogger(t *testing.T) {
+	hc := New()
+	if hc.logger != nil {
+		t.Errorf("hibp client logger was not nil. Expected nil, got: %p", hc.logger)
+	}
+
+	customerLogger := &bufio.Writer{}
+	hc = New(WithLogger(customerLogger))
+	if hc.logger != customerLogger {
+		t.Errorf("hibp client custom logger was not set properly. Expected %p, got: %p",
+			customerLogger, hc.logger)
+	}
+
+	hc = New(WithLogger(nil))
+	if hc.logger != nil {
+		t.Errorf("hibp client custom logger was not set properly. Expected nil, got: %p", hc.logger)
 	}
 }
 


### PR DESCRIPTION
Instead of directly writing with `log.Printf`, this allows the user to specify a custom logger via an `io.Writer`.  If none is specified, then no logging will be done.

Historically, this would log an "API rate limit hit" message every time it needed to sleep a bit due to rate limiting, which, in a production appliction, is frequent and cluttered the logs.