### PR TITLE
Add the subscription/status API

### DIFF
--- a/hibp.go
+++ b/hibp.go
@@ -77,8 +77,9 @@ type Client struct {
 	PwnedPassAPI     *PwnedPassAPI         // Reference to the PwnedPassAPI API
 	PwnedPassAPIOpts *PwnedPasswordOptions // Additional options for the PwnedPassAPI API
 
-	BreachAPI *BreachAPI // Reference to the BreachAPI
-	PasteAPI  *PasteAPI  // Reference to the PasteAPI
+	BreachAPI       *BreachAPI       // Reference to the BreachAPI
+	PasteAPI        *PasteAPI        // Reference to the PasteAPI
+	SubscriptionAPI *SubscriptionAPI // Reference to the SubscriptionAPI
 }
 
 // Option is a function that is used for grouping of Client options.
@@ -114,6 +115,7 @@ func New(options ...Option) Client {
 	}
 	c.BreachAPI = &BreachAPI{hibp: &c}
 	c.PasteAPI = &PasteAPI{hibp: &c}
+	c.SubscriptionAPI = &SubscriptionAPI{hibp: &c}
 
 	return c
 }

--- a/subscription.go
+++ b/subscription.go
@@ -1,0 +1,42 @@
+package hibp
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+type SubscriptionAPI struct {
+	hibp *Client // References back to the parent HIBP client
+}
+
+type SubscriptionStatus struct {
+	// SubscriptionName is the name representing the subscription being either "Pwned 1", "Pwned 2", "Pwned 3" or "Pwned 4".
+	SubscriptionName string `json:"SubscriptionName"`
+	// Description is a human readable sentence explaining the scope of the subscription.
+	Description string `json:"Description"`
+	// SubscribedUntil is the date and time the current subscription ends in ISO 8601 format.
+	SubscribedUntil RenewalTime `json:"SubscribedUntil"`
+	// Rpm is the rate limit in requests per minute. This applies to the rate the breach search by email address API can be requested.
+	Rpm int `json:"Rpm"`
+	// DomainSearchMaxBreachedAccounts is the size of the largest domain the subscription can search.
+	// This is expressed in the total number of breached accounts on the domain, excluding those that appear solely in spam list.
+	// This will be nil if there is no limit.
+	DomainSearchMaxBreachedAccounts *int `json:"DomainSearchMaxBreachedAccounts"`
+}
+
+// Status returns details of the current subscription.
+func (s *SubscriptionAPI) Status() (*SubscriptionStatus, *http.Response, error) {
+	au := fmt.Sprintf("%s/subscription/status", BaseURL)
+	hb, hr, err := s.hibp.HTTPResBody(http.MethodGet, au, nil)
+	if err != nil {
+		return nil, hr, err
+	}
+
+	var subscriptionStatus *SubscriptionStatus
+	if err := json.Unmarshal(hb, &subscriptionStatus); err != nil {
+		return nil, hr, err
+	}
+
+	return subscriptionStatus, hr, nil
+}

--- a/subscription_test.go
+++ b/subscription_test.go
@@ -1,0 +1,60 @@
+package hibp
+
+import (
+	"net/http"
+	"os"
+	"testing"
+)
+
+// TestSubscriptionAPI_Status tests the Status() method of the subscription API
+func TestSubscriptionAPI_Status(t *testing.T) {
+	t.Run("Unauthenticated", func(t *testing.T) {
+		hc := New(WithRateLimitSleep())
+		subscriptionStatus, httpResponse, err := hc.SubscriptionAPI.Status()
+		if err == nil {
+			t.Errorf("err is nil but expected a failure")
+		}
+		if httpResponse == nil {
+			t.Errorf("httpResponse is nil")
+		} else {
+			if httpResponse.StatusCode != http.StatusUnauthorized {
+				t.Errorf("unexpected status code: %d", httpResponse.StatusCode)
+			}
+		}
+		if subscriptionStatus != nil {
+			t.Errorf("subscriptionStatus is not nil")
+		}
+	})
+	t.Run("Authenticated", func(t *testing.T) {
+		apiKey := os.Getenv("HIBP_API_KEY")
+		if apiKey == "" {
+			t.SkipNow()
+		}
+		hc := New(WithAPIKey(apiKey), WithRateLimitSleep())
+
+		subscriptionStatus, httpResponse, err := hc.SubscriptionAPI.Status()
+		if err != nil {
+			t.Error(err)
+		}
+		if httpResponse == nil {
+			t.Errorf("httpResponse is nil")
+		} else {
+			if httpResponse.StatusCode != http.StatusOK {
+				t.Errorf("unexpected status code: %d", httpResponse.StatusCode)
+			}
+		}
+		if subscriptionStatus == nil {
+			t.Errorf("subscriptionStatus is nil")
+		} else {
+			if subscriptionStatus.Description == "" {
+				t.Errorf("Description is empty")
+			}
+			if subscriptionStatus.SubscriptionName == "" {
+				t.Errorf("SubscriptionName is empty")
+			}
+			if subscriptionStatus.Rpm <= 0 {
+				t.Errorf("Rpm is impossible")
+			}
+		}
+	})
+}


### PR DESCRIPTION
This adds support for the Subscription API, which currently has just one method: Status.  This can be used to see what kind of subscription the API key represents.