### PR TITLE
Sleep 1 second longer than required

### DIFF
--- a/hibp.go
+++ b/hibp.go
@@ -253,6 +253,7 @@ func (c *Client) HTTPResBody(m string, p string, q map[string]string) ([]byte, *
 		if err != nil {
 			return nil, hr, err
 		}
+		delayTime += 1 * time.Second // Wait for one additional second to ensure that we don't retry too early due to integer rounding issues.
 		if c.logger != nil {
 			_, _ = c.logger.Write([]byte(fmt.Sprintf("API rate limit hit. Retrying request in %s\n", delayTime.String())))
 		}


### PR DESCRIPTION
When sleeping in order to wait for the rate limit to pass, this adds one additional second to the sleep time so that we account for any integer rounding issues.  We don't want to try again before the server thinks it's time to because it'll hit us with a 5-minute sleep.