### PR TITLE
BREAKING CHANGE: Refactor date handling with unified APIDate type

### DIFF
--- a/breach.go
+++ b/breach.go
@@ -113,17 +113,11 @@ type SubscribedDomains struct {
 	// The date and time the current subscription ends in ISO 8601 format. The
 	// PwnCountExcludingSpamListsAtLastSubscriptionRenewal value is locked in until this time (will
 	// be null if there have been no subscriptions).
-	NextSubscriptionRenewal RenewalTime `json:"NextSubscriptionRenewal"`
+	NextSubscriptionRenewal APIDate `json:"NextSubscriptionRenewal"`
 }
 
 // BreachOption is an additional option the can be set for the BreachApiClient
 type BreachOption func(*BreachAPI)
-
-// APIDate is a date string without time returned by the API represented as time.Time type
-type APIDate time.Time
-
-// RenewalTime is a timestamp returned by the API that doesn't have timezone information
-type RenewalTime time.Time
 
 // Breaches returns a list of all breaches in the HIBP system
 func (b *BreachAPI) Breaches(options ...BreachOption) ([]*Breach, *http.Response, error) {
@@ -276,50 +270,6 @@ func WithoutUnverified() BreachOption {
 	return func(b *BreachAPI) {
 		b.noUnverified = true
 	}
-}
-
-// UnmarshalJSON for the APIDate type converts a give date string into a time.Time type
-func (d *APIDate) UnmarshalJSON(s []byte) error {
-	ds := string(s[1 : len(s)-1])
-	if ds == "null" || ds == "" {
-		return nil
-	}
-
-	pd, err := time.Parse("2006-01-02", ds)
-	if err != nil {
-		return fmt.Errorf("convert API date string to time.Time type: %w", err)
-	}
-
-	*(*time.Time)(d) = pd
-	return nil
-}
-
-// Time adds a Time() method to the APIDate converted time.Time type
-func (d *APIDate) Time() time.Time {
-	dp := *d
-	return time.Time(dp)
-}
-
-// UnmarshalJSON for the RenewalTime type converts a give date string into a time.Time type
-func (d *RenewalTime) UnmarshalJSON(s []byte) error {
-	ds := string(s[1 : len(s)-1])
-	if ds == "null" || ds == "" {
-		return nil
-	}
-
-	pd, err := time.Parse("2006-01-02T15:04:05", ds)
-	if err != nil {
-		return fmt.Errorf("convert API date string to time.Time type: %w", err)
-	}
-
-	*(*time.Time)(d) = pd
-	return nil
-}
-
-// Time adds a Time() method to the RenewalTime converted time.Time type
-func (d *RenewalTime) Time() time.Time {
-	dp := *d
-	return time.Time(dp)
 }
 
 // setBreachOpts returns a map of default settings and overridden values from different BreachOption

--- a/breach_test.go
+++ b/breach_test.go
@@ -352,7 +352,7 @@ func TestBreachAPI_SubscribedDomains(t *testing.T) {
 				t.Error("domain name is missing")
 			}
 
-			if domain.NextSubscriptionRenewal.Time().IsZero() {
+			if domain.NextSubscriptionRenewal.IsZero() {
 				t.Error("next subscription renewal is missing")
 			}
 		})
@@ -427,7 +427,7 @@ func TestAPIDate_UnmarshalJSON_Time(t *testing.T) {
 				return
 			}
 			if !tc.nil {
-				tdd := td.Date.Time().Format("2006-01-02")
+				tdd := td.Date.Format("2006-01-02")
 				if tdd != tc.d && !tc.sf {
 					t.Errorf(`unmarshal of APIDate type failed. Expected: %q, got %q"`, tc.d, tdd)
 				}
@@ -447,7 +447,7 @@ func ExampleBreachAPI_Breaches_getAllBreaches() {
 	if len(bl) != 0 {
 		for _, b := range bl {
 			fmt.Printf("Found breach:\n\tName: %s\n\tDomain: %s\n\tBreach date: %s\n\n",
-				b.Name, b.Domain, b.BreachDate.Time().Format("Mon, 2. January 2006"))
+				b.Name, b.Domain, b.BreachDate.Format("Mon, 2. January 2006"))
 		}
 	}
 }
@@ -484,7 +484,7 @@ func ExampleBreachAPI_BreachByName() {
 	if bd != nil {
 		fmt.Println("Details of the 'Adobe' breach:")
 		fmt.Printf("\tDomain: %s\n", bd.Domain)
-		fmt.Printf("\tBreach date: %s\n", bd.BreachDate.Time().Format("2006-01-02"))
+		fmt.Printf("\tBreach date: %s\n", bd.BreachDate.Format("2006-01-02"))
 		fmt.Printf("\tAdded to HIBP: %s\n", bd.AddedDate.String())
 	}
 }

--- a/json.go
+++ b/json.go
@@ -1,0 +1,38 @@
+package hibp
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// APIDate is type wrapper for datestamp (without time) returned by the HIBP API
+type APIDate struct {
+	time.Time
+}
+
+// UnmarshalJSON for the APIDate type converts a give date string into a time.Time type
+func (a *APIDate) UnmarshalJSON(p []byte) error {
+	input := strings.ReplaceAll(string(p), `"`, ``)
+	if input == "null" || input == "" {
+		return nil
+	}
+
+	var parsed time.Time
+	var err error
+	switch len(input) {
+	case 10:
+		parsed, err = time.Parse("2006-01-02", input)
+	case 19:
+		parsed, err = time.Parse("2006-01-02T15:04:05", input)
+	default:
+		return errors.New("failed to parse JSON string as API date: unknown date format")
+	}
+	if err != nil {
+		return fmt.Errorf("failed to parse JSON string as API date: %s", err)
+	}
+
+	a.Time = parsed
+	return nil
+}

--- a/subscription.go
+++ b/subscription.go
@@ -20,7 +20,7 @@ type SubscriptionStatus struct {
 	// Description is a human readable sentence explaining the scope of the subscription.
 	Description string `json:"Description"`
 	// SubscribedUntil is the date and time the current subscription ends in ISO 8601 format.
-	SubscribedUntil RenewalTime `json:"SubscribedUntil"`
+	SubscribedUntil APIDate `json:"SubscribedUntil"`
 	// Rpm is the rate limit in requests per minute. This applies to the rate the breach search by email address API can be requested.
 	Rpm int `json:"Rpm"`
 	// DomainSearchMaxBreachedAccounts is the size of the largest domain the subscription can search.


### PR DESCRIPTION
Replaced RenewalTime with APIDate and consolidated date parsing logic into a single implementation for greater consistency and maintainability. Removed redundant methods and streamlined code across breach and subscription handling. Updated tests to reflect the changes.