### PR TITLE
Add error handling for missing API key

### DIFF
--- a/breach.go
+++ b/breach.go
@@ -217,6 +217,9 @@ func (b *BreachAPI) DataClasses() ([]string, *http.Response, error) {
 // Reference: https://haveibeenpwned.com/API/v3#BreachesForAccount
 func (b *BreachAPI) BreachedAccount(a string, options ...BreachOption) ([]Breach, *http.Response, error) {
 	var bd []Breach
+	if err := requiresAPIKey(b.hibp); err != nil {
+		return bd, nil, err
+	}
 	qp := b.setBreachOpts(options...)
 
 	if a == "" {
@@ -248,6 +251,9 @@ func (b *BreachAPI) BreachedAccount(a string, options ...BreachOption) ([]Breach
 //
 // Reference: https://haveibeenpwned.com/API/v3#SubscribedDomains
 func (b *BreachAPI) SubscribedDomains() ([]SubscribedDomains, *http.Response, error) {
+	if err := requiresAPIKey(b.hibp); err != nil {
+		return nil, nil, err
+	}
 	au := fmt.Sprintf("%s/subscribeddomains", BaseURL)
 	hb, hr, err := b.hibp.HTTPResBody(http.MethodGet, au, nil)
 	if err != nil {
@@ -269,6 +275,9 @@ func (b *BreachAPI) SubscribedDomains() ([]SubscribedDomains, *http.Response, er
 //
 // https://haveibeenpwned.com/API/v3#BreachesForDomain
 func (b *BreachAPI) BreachedDomain(domain string) (map[string][]string, *http.Response, error) {
+	if err := requiresAPIKey(b.hibp); err != nil {
+		return nil, nil, err
+	}
 	var bd map[string][]string
 	au := fmt.Sprintf("%s/breacheddomain/%s", BaseURL, domain)
 	hb, hr, err := b.hibp.HTTPResBody(http.MethodGet, au, nil)

--- a/breach_test.go
+++ b/breach_test.go
@@ -498,6 +498,20 @@ func TestBreachAPI_BreachedAccount(t *testing.T) {
 			t.Error("expected to fail on broken JSON")
 		}
 	})
+	t.Run("account request without API key should fail", func(t *testing.T) {
+		email := "toni.tester@domain.tld"
+		resp := fmt.Sprintf(ServerResponseBreachAccount, email)
+		server := httptest.NewServer(newTestFileHandler(t, resp))
+		defer server.Close()
+		hc := New(WithHTTPClient(newTestClient(t, server.URL)))
+		_, _, err := hc.BreachAPI.BreachedAccount("does.not.exist@domain.tld")
+		if err == nil {
+			t.Error("expected to fail without API key")
+		}
+		if !errors.Is(err, ErrMethodRequiresAPIKey) {
+			t.Errorf("expected to error to be: %s, got: %s", ErrMethodRequiresAPIKey, err)
+		}
+	})
 }
 
 func TestBreachAPI_SubscribedDomains(t *testing.T) {
@@ -544,6 +558,18 @@ func TestBreachAPI_SubscribedDomains(t *testing.T) {
 		_, _, err := hc.BreachAPI.SubscribedDomains()
 		if err == nil {
 			t.Errorf("expected to fail on broken JSON")
+		}
+	})
+	t.Run("subscribed domains without API key should fail", func(t *testing.T) {
+		server := httptest.NewServer(newTestFileHandler(t, ServerResponseBreachSubscribedDomains))
+		defer server.Close()
+		hc := New(WithHTTPClient(newTestClient(t, server.URL)))
+		_, _, err := hc.BreachAPI.SubscribedDomains()
+		if err == nil {
+			t.Errorf("expected subscribed domains to fail without API key")
+		}
+		if !errors.Is(err, ErrMethodRequiresAPIKey) {
+			t.Errorf("expected to error to be: %s, got: %s", ErrMethodRequiresAPIKey, err)
 		}
 	})
 }
@@ -593,6 +619,18 @@ func TestBreachAPI_BreachedDomain(t *testing.T) {
 		_, _, err := hc.BreachAPI.BreachedDomain("domain.tld")
 		if err == nil {
 			t.Errorf("expected to fail on broken JSON")
+		}
+	})
+	t.Run("breached domain without API key should fail", func(t *testing.T) {
+		server := httptest.NewServer(newTestFileHandler(t, ServerResponseBreachedDomain))
+		defer server.Close()
+		hc := New(WithHTTPClient(newTestClient(t, server.URL)))
+		_, _, err := hc.BreachAPI.BreachedDomain("domain.tld")
+		if err == nil {
+			t.Errorf("expected to fail on missing API key")
+		}
+		if !errors.Is(err, ErrMethodRequiresAPIKey) {
+			t.Errorf("expected to error to be: %s, got: %s", ErrMethodRequiresAPIKey, err)
 		}
 	})
 }

--- a/breach_test.go
+++ b/breach_test.go
@@ -443,7 +443,7 @@ func TestBreachAPI_BreachedAccount(t *testing.T) {
 		resp := fmt.Sprintf(ServerResponseBreachAccount, email)
 		server := httptest.NewServer(newTestFileHandler(t, resp))
 		defer server.Close()
-		hc := New(WithHTTPClient(newTestClient(t, server.URL)))
+		hc := New(WithHTTPClient(newTestClient(t, server.URL)), WithAPIKey(apiKey))
 		breaches, _, err := hc.BreachAPI.BreachedAccount("toni.tester@domain.tld")
 		if err != nil {
 			t.Errorf("failed to get breached account: %s", err)
@@ -457,7 +457,7 @@ func TestBreachAPI_BreachedAccount(t *testing.T) {
 		resp := fmt.Sprintf(ServerResponseBreachAccount, email)
 		server := httptest.NewServer(newTestFileHandler(t, resp))
 		defer server.Close()
-		hc := New(WithHTTPClient(newTestClient(t, server.URL)))
+		hc := New(WithHTTPClient(newTestClient(t, server.URL)), WithAPIKey(apiKey))
 		_, _, err := hc.BreachAPI.BreachedAccount("")
 		if err == nil {
 			t.Error("expected to fail with empty account id")
@@ -469,7 +469,7 @@ func TestBreachAPI_BreachedAccount(t *testing.T) {
 	t.Run("account request with no findings empty breaches list", func(t *testing.T) {
 		server := httptest.NewServer(newTestFailureHandler(t, http.StatusNotFound))
 		defer server.Close()
-		hc := New(WithHTTPClient(newTestClient(t, server.URL)))
+		hc := New(WithHTTPClient(newTestClient(t, server.URL)), WithAPIKey(apiKey))
 		breach, _, err := hc.BreachAPI.BreachedAccount("does.not.exist@domain.tld")
 		if err != nil {
 			t.Errorf("failed to get breached account: %s", err)
@@ -481,7 +481,7 @@ func TestBreachAPI_BreachedAccount(t *testing.T) {
 	t.Run("account request fails on HTTP error", func(t *testing.T) {
 		server := httptest.NewServer(newTestFailureHandler(t, http.StatusInternalServerError))
 		defer server.Close()
-		hc := New(WithHTTPClient(newTestClient(t, server.URL)))
+		hc := New(WithHTTPClient(newTestClient(t, server.URL)), WithAPIKey(apiKey))
 		_, _, err := hc.BreachAPI.BreachedAccount("does.not.exist@domain.tld")
 		if err == nil {
 			t.Error("expected to fail on HTTP error")
@@ -492,7 +492,7 @@ func TestBreachAPI_BreachedAccount(t *testing.T) {
 		resp := fmt.Sprintf(ServerResponseBreachAccountBroken, email)
 		server := httptest.NewServer(newTestFileHandler(t, resp))
 		defer server.Close()
-		hc := New(WithHTTPClient(newTestClient(t, server.URL)))
+		hc := New(WithHTTPClient(newTestClient(t, server.URL)), WithAPIKey(apiKey))
 		_, _, err := hc.BreachAPI.BreachedAccount("does.not.exist@domain.tld")
 		if err == nil {
 			t.Error("expected to fail on broken JSON")
@@ -501,13 +501,17 @@ func TestBreachAPI_BreachedAccount(t *testing.T) {
 }
 
 func TestBreachAPI_SubscribedDomains(t *testing.T) {
+	apiKey := os.Getenv("HIBP_API_KEY")
+	if apiKey == "" {
+		t.SkipNow()
+	}
 	t.Run("subscribed domains successfully returns data", func(t *testing.T) {
 		server := httptest.NewServer(newTestFileHandler(t, ServerResponseBreachSubscribedDomains))
 		defer server.Close()
-		hc := New(WithHTTPClient(newTestClient(t, server.URL)))
+		hc := New(WithHTTPClient(newTestClient(t, server.URL)), WithAPIKey(apiKey))
 		domains, _, err := hc.BreachAPI.SubscribedDomains()
 		if err != nil {
-			t.Errorf("failed to get subscribed domains: %s", err)
+			t.Fatalf("failed to get subscribed domains: %s", err)
 		}
 		if len(domains) != 1 {
 			t.Errorf("expected %d subscribed domains, got %d", 1, len(domains))
@@ -527,7 +531,7 @@ func TestBreachAPI_SubscribedDomains(t *testing.T) {
 	t.Run("subscribed domains should fail on HTTP error", func(t *testing.T) {
 		server := httptest.NewServer(newTestFailureHandler(t, http.StatusInternalServerError))
 		defer server.Close()
-		hc := New(WithHTTPClient(newTestClient(t, server.URL)))
+		hc := New(WithHTTPClient(newTestClient(t, server.URL)), WithAPIKey(apiKey))
 		_, _, err := hc.BreachAPI.SubscribedDomains()
 		if err == nil {
 			t.Errorf("expected to fail on HTTP error")
@@ -536,7 +540,7 @@ func TestBreachAPI_SubscribedDomains(t *testing.T) {
 	t.Run("subscribed domains with broken JSON should fail", func(t *testing.T) {
 		server := httptest.NewServer(newTestFileHandler(t, ServerResponseBreachSubscribedDomainsBroken))
 		defer server.Close()
-		hc := New(WithHTTPClient(newTestClient(t, server.URL)))
+		hc := New(WithHTTPClient(newTestClient(t, server.URL)), WithAPIKey(apiKey))
 		_, _, err := hc.BreachAPI.SubscribedDomains()
 		if err == nil {
 			t.Errorf("expected to fail on broken JSON")
@@ -545,13 +549,17 @@ func TestBreachAPI_SubscribedDomains(t *testing.T) {
 }
 
 func TestBreachAPI_BreachedDomain(t *testing.T) {
+	apiKey := os.Getenv("HIBP_API_KEY")
+	if apiKey == "" {
+		t.SkipNow()
+	}
 	t.Run("breached domain successfully returns data", func(t *testing.T) {
 		server := httptest.NewServer(newTestFileHandler(t, ServerResponseBreachedDomain))
 		defer server.Close()
-		hc := New(WithHTTPClient(newTestClient(t, server.URL)))
+		hc := New(WithHTTPClient(newTestClient(t, server.URL)), WithAPIKey(apiKey))
 		accounts, _, err := hc.BreachAPI.BreachedDomain("domain.tld")
 		if err != nil {
-			t.Errorf("failed to get breached domains %s", err)
+			t.Errorf("failed to get breached domains: %s", err)
 		}
 		if len(accounts) != 6 {
 			t.Errorf("expected %d breached accounts, got %d", 6, len(accounts))
@@ -560,7 +568,7 @@ func TestBreachAPI_BreachedDomain(t *testing.T) {
 	t.Run("breached domain with no breaches returns empty list", func(t *testing.T) {
 		server := httptest.NewServer(newTestFailureHandler(t, http.StatusNotFound))
 		defer server.Close()
-		hc := New(WithHTTPClient(newTestClient(t, server.URL)))
+		hc := New(WithHTTPClient(newTestClient(t, server.URL)), WithAPIKey(apiKey))
 		accounts, _, err := hc.BreachAPI.BreachedDomain("domain.tld")
 		if err != nil {
 			t.Errorf("failed to get breached domains %s", err)
@@ -572,7 +580,7 @@ func TestBreachAPI_BreachedDomain(t *testing.T) {
 	t.Run("breached domain with HTTP error should fail", func(t *testing.T) {
 		server := httptest.NewServer(newTestFailureHandler(t, http.StatusInternalServerError))
 		defer server.Close()
-		hc := New(WithHTTPClient(newTestClient(t, server.URL)))
+		hc := New(WithHTTPClient(newTestClient(t, server.URL)), WithAPIKey(apiKey))
 		_, _, err := hc.BreachAPI.BreachedDomain("domain.tld")
 		if err == nil {
 			t.Errorf("expected to fail on HTTP error")
@@ -581,7 +589,7 @@ func TestBreachAPI_BreachedDomain(t *testing.T) {
 	t.Run("breached domain with broken JSON should fail", func(t *testing.T) {
 		server := httptest.NewServer(newTestFileHandler(t, ServerResponseBreachedDomainBroken))
 		defer server.Close()
-		hc := New(WithHTTPClient(newTestClient(t, server.URL)))
+		hc := New(WithHTTPClient(newTestClient(t, server.URL)), WithAPIKey(apiKey))
 		_, _, err := hc.BreachAPI.BreachedDomain("domain.tld")
 		if err == nil {
 			t.Errorf("expected to fail on broken JSON")

--- a/hibp.go
+++ b/hibp.go
@@ -68,6 +68,9 @@ var (
 
 	// ErrHTTPRequestMethodUnsupported indicates that the HTTP request method used is not supported.
 	ErrHTTPRequestMethodUnsupported = errors.New("HTTP request method not supported")
+
+	// ErrMethodRequiresAPIKey indicates that the invoked method cannot proceed without providing a valid API key.
+	ErrMethodRequiresAPIKey = errors.New("this method requires an API key")
 )
 
 // HTTPClient is an interface representing an HTTP client capable of executing HTTP requests and
@@ -291,4 +294,13 @@ func httpClient(to time.Duration) *http.Client {
 	}
 
 	return hc
+}
+
+// requiresAPIKey ensures that the client has a valid API key set. It returns ErrMethodRequiresAPIKey if the
+// key is missing.
+func requiresAPIKey(c *Client) error {
+	if c.ak == "" {
+		return ErrMethodRequiresAPIKey
+	}
+	return nil
 }

--- a/subscription.go
+++ b/subscription.go
@@ -48,6 +48,9 @@ type SubscriptionStatus struct {
 // Reference: https://haveibeenpwned.com/API/v3#SubscriptionStatus
 func (s *SubscriptionAPI) Status() (SubscriptionStatus, *http.Response, error) {
 	var status SubscriptionStatus
+	if err := requiresAPIKey(s.hibp); err != nil {
+		return status, nil, err
+	}
 	au := fmt.Sprintf("%s/subscription/status", BaseURL)
 	hb, hr, err := s.hibp.HTTPResBody(http.MethodGet, au, nil)
 	if err != nil {

--- a/subscription_test.go
+++ b/subscription_test.go
@@ -30,7 +30,7 @@ func TestSubscriptionAPI_Status(t *testing.T) {
 	t.Run("subscription status is returned successfully", func(t *testing.T) {
 		server := httptest.NewServer(newTestFileHandler(t, ServerResponseSubscriptionStatus))
 		defer server.Close()
-		hc := New(WithHTTPClient(newTestClient(t, server.URL)))
+		hc := New(WithHTTPClient(newTestClient(t, server.URL)), WithAPIKey(apiKey))
 		status, _, err := hc.SubscriptionAPI.Status()
 		if err != nil {
 			t.Errorf("failed to get subscription status: %s", err)
@@ -45,7 +45,7 @@ func TestSubscriptionAPI_Status(t *testing.T) {
 	t.Run("subscription status fails on HTTP error", func(t *testing.T) {
 		server := httptest.NewServer(newTestFailureHandler(t, http.StatusInternalServerError))
 		defer server.Close()
-		hc := New(WithHTTPClient(newTestClient(t, server.URL)))
+		hc := New(WithHTTPClient(newTestClient(t, server.URL)), WithAPIKey(apiKey))
 		_, _, err := hc.SubscriptionAPI.Status()
 		if err == nil {
 			t.Error("expected subscription status request to fail on HTTP error")
@@ -54,7 +54,7 @@ func TestSubscriptionAPI_Status(t *testing.T) {
 	t.Run("subscription status fails on broken JSON", func(t *testing.T) {
 		server := httptest.NewServer(newTestFileHandler(t, ServerResponseSubscriptionStatusBroken))
 		defer server.Close()
-		hc := New(WithHTTPClient(newTestClient(t, server.URL)))
+		hc := New(WithHTTPClient(newTestClient(t, server.URL)), WithAPIKey(apiKey))
 		_, _, err := hc.SubscriptionAPI.Status()
 		if err == nil {
 			t.Error("expected subscription status request to fail on broken JSON")
@@ -64,7 +64,8 @@ func TestSubscriptionAPI_Status(t *testing.T) {
 		run := 0
 		server := httptest.NewServer(newTestRetryHandler(t, &run, false))
 		defer server.Close()
-		hc := New(WithHTTPClient(newTestClient(t, server.URL)), WithRateLimitSleep(), WithLogger(newTestLogger(t)))
+		hc := New(WithHTTPClient(newTestClient(t, server.URL)), WithRateLimitSleep(), WithLogger(newTestLogger(t)),
+			WithAPIKey(apiKey))
 		_, _, err := hc.SubscriptionAPI.Status()
 		if err != nil {
 			t.Errorf("failed to get subscription status: %s", err)
@@ -74,7 +75,7 @@ func TestSubscriptionAPI_Status(t *testing.T) {
 		run := 0
 		server := httptest.NewServer(newTestRetryHandler(t, &run, false))
 		defer server.Close()
-		hc := New(WithHTTPClient(newTestClient(t, server.URL)), WithLogger(newTestLogger(t)))
+		hc := New(WithHTTPClient(newTestClient(t, server.URL)), WithLogger(newTestLogger(t)), WithAPIKey(apiKey))
 		_, hr, err := hc.SubscriptionAPI.Status()
 		if err == nil {
 			t.Error("expected subscription status request to fail on HTTP error")

--- a/subscription_test.go
+++ b/subscription_test.go
@@ -5,6 +5,7 @@
 package hibp
 
 import (
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -85,6 +86,18 @@ func TestSubscriptionAPI_Status(t *testing.T) {
 		}
 		if hr.StatusCode != http.StatusTooManyRequests {
 			t.Errorf("expected HTTP status code to be %d, got %d", http.StatusTooManyRequests, hr.StatusCode)
+		}
+	})
+	t.Run("subscription status fails if no API key is provided", func(t *testing.T) {
+		server := httptest.NewServer(newTestFileHandler(t, ServerResponseSubscriptionStatus))
+		defer server.Close()
+		hc := New(WithHTTPClient(newTestClient(t, server.URL)))
+		_, _, err := hc.SubscriptionAPI.Status()
+		if err == nil {
+			t.Error("expected subscription status request to fail if no API key is provided")
+		}
+		if !errors.Is(err, ErrMethodRequiresAPIKey) {
+			t.Errorf("expected error to be %q, got %q", ErrMethodRequiresAPIKey, err)
 		}
 	})
 }


### PR DESCRIPTION
This PR introduces a new error, `ErrMethodRequiresAPIKey`, and the `requiresAPIKey` method to ensure that methods requiring an API key cannot proceed without one. This enhances input validation and prevents misuse of API-dependent methods.